### PR TITLE
Revise README for clarity and refactor agenda query logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,95 +1,271 @@
-# tele_bot_node
+# Tele Bot Node
 
-Telegram bill-management bot split into three apps:
+[![Node.js](https://img.shields.io/badge/Node.js-ES_modules-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
+[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-17-4169E1?logo=postgresql&logoColor=white)](https://www.postgresql.org/)
+[![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?logo=docker&logoColor=white)](https://docs.docker.com/compose/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+A Telegram bot for organizing shared bills, tracking who has paid, and managing
+PIX payment details. It includes a REST API, a PostgreSQL database, and a React
+admin dashboard for managing the system from a browser.
+
+## Highlights
+
+- Create bills and split them between members of a Telegram group or channel.
+- Track paid and unpaid participants per bill.
+- Register and manage PIX keys and banks.
+- Discover groups, channels, users, and forum topics where the bot is active.
+- Route new-bill and payment-confirmation messages to selected Telegram topics.
+- Manage users, bills, PIX keys, banks, and bot installations from an admin UI.
+- Run the complete stack with Docker Compose.
+
+## Architecture
 
 ```text
-Telegram <-> tele_bot <-> HTTP API <-> backend <-> PostgreSQL
-                         ^
-                         |
-                  admin_panel
+                         ┌─────────────────┐
+Telegram ── polling ───▶ │  Telegram Bot   │
+                         └────────┬────────┘
+                                  │ HTTP
+                                  ▼
+┌─────────────────┐      ┌─────────────────┐      ┌─────────────────┐
+│  Admin Panel    │ ───▶ │  Express API    │ ───▶ │   PostgreSQL    │
+│  React + Vite   │ HTTP │  Node.js        │      │                 │
+└─────────────────┘      └─────────────────┘      └─────────────────┘
 ```
 
-`tele_bot` owns Telegram polling, command flows, in-memory state, keyboards, and
-messages. `backend` owns PostgreSQL access, business rules, users, PIX keys,
-agenda payments, and dynamic payment members. `admin_panel` is a browser admin
-interface that talks to `backend` through HTTP only.
+| Service | Responsibility | Default port |
+| --- | --- | ---: |
+| `tele_bot` | Telegram polling, commands, keyboards, and conversation state | — |
+| `backend` | REST API, business rules, and database access | `3000` |
+| `admin_panel` | Browser-based administration interface | `3001` |
+| `postgres` | Persistent application data | internal only |
+| `adminer` | Optional database administration UI | `8080` |
 
-## Structure
+The bot and admin panel communicate with the backend exclusively over HTTP;
+neither accesses PostgreSQL directly.
+
+## Quick Start
+
+### Requirements
+
+- [Docker](https://docs.docker.com/get-docker/) with Docker Compose
+- A Telegram bot token created through
+  [@BotFather](https://t.me/BotFather)
+
+### Development
+
+1. Clone the repository and enter it:
+
+   ```bash
+   git clone https://github.com/prinako/tele_bot_node.git
+   cd tele_bot_node
+   ```
+
+2. Create your environment file:
+
+   ```bash
+   cp env_example .env
+   ```
+
+3. Set at least `BOT_TOKEN` and `POSTGRES_PASSWORD` in `.env`.
+
+4. Build and start the development stack:
+
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+   ```
+
+5. Check that the API is healthy:
+
+   ```bash
+   curl http://localhost:3000/health
+   ```
+
+The admin panel is available at <http://localhost:3001> and Adminer at
+<http://localhost:8080>. Follow all service logs with:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml logs -f
+```
+
+Stop the stack with the same Compose files:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml down
+```
+
+## Configuration
+
+| Variable | Required | Default | Description |
+| --- | :---: | --- | --- |
+| `BOT_TOKEN` | Yes | — | Telegram token issued by BotFather. |
+| `POSTGRES_PASSWORD` | Recommended | `telebot` | Password for the `telebot` database user. |
+| `BACKEND_PORT` | No | `3000` | Backend port exposed on the host. |
+| `BACKEND_URL` | No | `http://backend:3000` | API URL used by the bot outside the standard Compose setup. |
+| `ADMIN_PANEL_PORT` | No | `3001` | Admin panel port exposed on the host. |
+| `ADMINER_PORT` | No | `8080` | Adminer port exposed on the host. |
+| `VITE_BACKEND_URL` | No | `http://localhost:3000` | Browser-visible API URL baked into the admin build. |
+| `ALLOWED_USERS` | No | Empty | Comma-separated Telegram user IDs allowed by backend rules. |
+| `ADMIN_USERS` | No | Empty | Comma-separated Telegram user IDs with admin status. |
+| `CHAT_ID` | No | — | Legacy fallback Telegram chat ID. |
+| `BILLS_THREAD_ID` | No | — | Legacy fallback topic for new bills. |
+| `PAID_THREAD_ID` | No | — | Legacy fallback topic for payment confirmations. |
+| `LOG` | No | `false` | Enables additional logging when set to `true`. |
+
+`VITE_BACKEND_URL` is used by the visitor's browser, so it must be reachable
+from that browser. A Docker-internal hostname such as `backend` will not work
+for users outside the Compose network.
+
+## Bot Commands
+
+| Command | Purpose |
+| --- | --- |
+| `/start` | Start a conversation with the bot. |
+| `/agenda` | Create and split a new bill. |
+| `/pagou` | Mark a member's share as paid. |
+| `/whopaid` | View payment status for a bill. |
+| `/registerpix` | Register a PIX key. |
+| `/delete` | Delete a registered bill. |
+| `/cancel` | Cancel the current operation. |
+| `/help` | Show the available commands. |
+
+To create a bill, a user must first be seen in a group or channel where the bot
+is present. The flow then asks for the target chat, bill details, amount, and
+responsible members. The selected members determine how the amount is split.
+
+## Admin Panel
+
+The dashboard provides pages for:
+
+- Summary statistics
+- Users
+- Banks and PIX keys
+- Bills and bill details
+- Telegram groups and channels
+- Chat users, forum topics, and topic routing settings
+
+In **Groups & Channels → Chat Details → Settings**, an admin can choose which
+known topic receives new bills and which receives payment confirmations.
+
+> [!WARNING]
+> The admin panel currently has no authentication. Keep it on a trusted network,
+> behind a VPN, or behind an authenticated reverse proxy.
+
+## API Reference
+
+The API returns JSON. Its main routes are grouped below.
+
+<details>
+<summary><strong>Health and administration</strong></summary>
+
+| Method | Endpoint |
+| --- | --- |
+| `GET` | `/health` |
+| `GET` | `/api/admin/stats` |
+| `GET` | `/api/admin/pix` |
+| `GET` | `/api/admin/agenda` |
+
+</details>
+
+<details>
+<summary><strong>Users</strong></summary>
+
+| Method | Endpoint |
+| --- | --- |
+| `POST` | `/api/users/upsert` |
+| `GET` | `/api/users` |
+| `GET` | `/api/users/allowed` |
+| `GET` | `/api/users/:telegramId` |
+| `GET` | `/api/users/:telegramUserId/bot-installations` |
+| `GET` | `/api/users-ids/:telegramIds` |
+| `PATCH` | `/api/users/:telegramId` |
+
+</details>
+
+<details>
+<summary><strong>Banks and PIX keys</strong></summary>
+
+| Method | Endpoint |
+| --- | --- |
+| `GET` | `/api/banks` |
+| `GET` | `/api/banks/:id` |
+| `POST` | `/api/banks` |
+| `PATCH` | `/api/banks/:id` |
+| `POST` | `/api/pix` |
+| `GET` | `/api/pix?senderId=:telegramId&bank=:bank` |
+| `PATCH` | `/api/pix/:id` |
+
+</details>
+
+<details>
+<summary><strong>Bills and members</strong></summary>
+
+| Method | Endpoint |
+| --- | --- |
+| `POST` | `/api/agenda` |
+| `GET` | `/api/agenda` |
+| `GET` | `/api/agenda/user/:telegramId` |
+| `GET` | `/api/agenda/:id` |
+| `PATCH` | `/api/agenda/:id` |
+| `DELETE` | `/api/agenda/:id` |
+| `GET` | `/api/agenda/:id/members` |
+| `PATCH` | `/api/agenda/:id/members/:telegramId/paid` |
+| `PATCH` | `/api/agenda/:id/members/:telegramId/unpaid` |
+
+</details>
+
+<details>
+<summary><strong>Bot installations</strong></summary>
+
+| Method | Endpoint |
+| --- | --- |
+| `POST` | `/api/bot-installations/upsert` |
+| `GET` | `/api/bot-installations` |
+| `GET` | `/api/bot-installations/:telegramChatId` |
+| `POST` | `/api/bot-installations/topics/upsert` |
+| `GET` | `/api/bot-installations/:telegramChatId/topics` |
+| `POST` | `/api/bot-installations/users/upsert` |
+| `GET` | `/api/bot-installations/:telegramChatId/users` |
+| `PATCH` | `/api/bot-installations/:telegramChatId/topic-settings` |
+
+</details>
+
+## Project Structure
 
 ```text
-backend/
-  src/server.js
-  src/app.js
-  src/db/
-  src/routes/
-  src/controllers/
-  src/repositories/
-  src/services/
-  src/utils/
-
-tele_bot/
-  src/server.js
-  src/bot.js
-  src/api/backendClient.js
-  src/agendas/
-  src/auth/
-  src/schedules/
-  src/utilities/
-  src/commands/
-  src/handlers/
-  src/keyboards/
-  src/messages/
-  src/state/
-
-admin_panel/
-  src/main.js
-  src/api/backendClient.js
-  src/components/
-  src/pages/
-  src/styles/
+.
+├── admin_panel/            # React/Vite administration UI
+│   └── src/
+│       ├── api/
+│       ├── components/
+│       ├── pages/
+│       └── styles/
+├── backend/                # Express REST API and PostgreSQL access
+│   └── src/
+│       ├── config/
+│       ├── controllers/
+│       ├── db/
+│       ├── repositories/
+│       ├── routes/
+│       ├── services/
+│       └── utils/
+├── tele_bot/               # Telegram polling and interaction flows
+│   └── src/
+│       ├── agendas/
+│       ├── api/
+│       ├── auth/
+│       ├── handlers/
+│       ├── schedules/
+│       ├── state/
+│       └── utilities/
+├── docker-compose.yml      # Production services
+├── docker-compose.dev.yml  # Development builds, mounts, and commands
+└── env_example             # Environment variable template
 ```
-
-## Backend API
-
-- `GET /health`
-- `POST /api/users/upsert`
-- `GET /api/users`
-- `GET /api/users/allowed`
-- `GET /api/users/:telegramUserId/bot-installations`
-- `GET /api/users/:telegramId`
-- `PATCH /api/users/:telegramId`
-- `GET /api/banks`
-- `GET /api/banks/:id`
-- `POST /api/banks`
-- `PATCH /api/banks/:id`
-- `POST /api/pix`
-- `GET /api/pix?senderId=<telegramId>&bank=<bank>`
-- `PATCH /api/pix/:id`
-- `GET /api/admin/stats`
-- `GET /api/admin/pix`
-- `GET /api/admin/agenda`
-- `POST /api/bot-installations/upsert`
-- `GET /api/bot-installations`
-- `GET /api/bot-installations/:telegramChatId`
-- `POST /api/bot-installations/topics/upsert`
-- `GET /api/bot-installations/:telegramChatId/topics`
-- `POST /api/bot-installations/users/upsert`
-- `GET /api/bot-installations/:telegramChatId/users`
-- `PATCH /api/bot-installations/:telegramChatId/topic-settings`
-- `POST /api/agenda`
-- `GET /api/agenda`
-- `GET /api/agenda/user/:telegramId`
-- `GET /api/agenda/:id`
-- `PATCH /api/agenda/:id`
-- `DELETE /api/agenda/:id`
-- `GET /api/agenda/:id/members`
-- `PATCH /api/agenda/:id/members/:telegramId/paid`
-- `PATCH /api/agenda/:id/members/:telegramId/unpaid`
 
 ## Database
 
-The PostgreSQL schema lives at `backend/src/db/schema.sql` and keeps the dynamic
-design:
+The schema is defined in `backend/src/db/schema.sql` and contains:
 
 - `users`
 - `banks`
@@ -100,176 +276,67 @@ design:
 - `bot_installation_topics`
 - `bot_installation_users`
 
-Banks are stored in the backend PostgreSQL `banks` table and exposed through
-`GET /api/banks`. The Telegram bot uses this endpoint to build the bank
-keyboard.
-
-PIX keys reference banks through `pix_keys.bank_id`. API responses still include
-`bank` as the bank name for Telegram callback compatibility.
-
-Agenda creation:
-
-- Any user can start `/agenda`.
-- The bot first lists groups/channels where that user has been seen.
-- The user must select one group/channel to attach the bill to.
-- If the user belongs to no registered group/channel, agenda creation is
-  blocked.
-- After the amount, the bot lists users seen in the selected group/channel.
-  The selected users define who is responsible and how the bill is split.
-
-`bot_installations` stores Telegram groups, supergroups, and channels where the
-bot is present. Private chats are not stored as bot installations; private users
-are stored in `users`. `bot_installation_users` links users to the
-groups/channels where they were seen and tracks first seen, last seen, and
-message count. `bot_installation_topics` stores forum topics/message threads
-inside groups, supergroups, and channels.
-
-`bot_installations` can store per-chat agenda topic settings:
-
-- `agenda_register_topic_id`
-- `agenda_paid_topic_id`
-
-The schema is not in production yet. `schema.sql` is the single source of truth
-and runs automatically only on a **new** PostgreSQL data directory. After schema
-changes during development, reset the database:
+The backend applies the schema during startup. The development setup stores
+PostgreSQL data in the `postgres_data` Docker volume. To discard all local
+development data and rebuild the database, run:
 
 ```bash
-docker compose down
-sudo rm -rf /Kojo/Docker/tele_bot_node/postgres
-docker compose up -d postgres
-```
-
-## Environment
-
-```bash
-cp .env.example .env
-```
-
-```env
-BOT_TOKEN=
-POSTGRES_PASSWORD=
-
-BACKEND_PORT=3000
-BACKEND_URL=http://backend:3000
-
-ALLOWED_USERS=
-ADMIN_USERS=
-
-BILLS_THREAD_ID= # legacy fallback only
-PAID_THREAD_ID= # legacy fallback only
-CHAT_ID=
-
-LOG=false
-
-ADMIN_PANEL_PORT=3001
-VITE_BACKEND_URL=http://localhost:3000
-```
-
-## Docker Production
-
-```bash
-docker compose down --remove-orphans
-docker compose pull
-docker compose up -d
-docker compose logs -f admin_panel
-```
-
-The PostgreSQL data volume is mounted at `/Kojo/Docker/tele_bot_node/postgres`.
-
-The production admin panel image is built from `admin_panel/Dockerfile` by the
-Docker image workflow. Vite runs only during the Node build stage, then nginx
-serves the generated `dist` files on container port `80`.
-
-## Docker Development
-
-```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
 ```
 
-The development override bind mounts the app source and keeps each
-`node_modules` directory in a named Docker volume. The admin panel runs Vite on
-container port `5173` only in this mode.
+> [!CAUTION]
+> The `-v` flag permanently removes the development database volume. The
+> production Compose file instead bind-mounts PostgreSQL data from
+> `/Kojo/Docker/tele_bot_node/postgres`; back it up before changing or removing
+> that directory.
 
-If `tele-bot-admin-panel` fails with `vite: not found`, the container is usually
-running the development command in the wrong compose mode, or a bind mount has
-hidden `node_modules`. Use the production command above for nginx production, or
-use the development override command so dependencies are installed inside the
-container volume.
+## Run Services Without Docker
 
-## Admin Panel
-
-The admin panel runs on `http://localhost:3001` by default. It communicates with
-the backend through HTTP API calls from `admin_panel/src/api/backendClient.js`
-and does not connect to PostgreSQL directly.
-
-Pages:
-
-- Dashboard
-- Users
-- Banks
-- PIX Keys
-- Agenda
-- Agenda Details
-- Groups & Channels
-- Chat Details
-
-For Docker, `VITE_BACKEND_URL` is a browser-side URL baked into the Vite build.
-The default is `http://localhost:3000`, so the backend port must be exposed to
-the browser.
-
-The admin panel includes a Groups & Channels page showing Telegram groups,
-supergroups, and channels where the bot is active, plus users and topics
-registered under each chat.
-
-In Groups & Channels -> Chat Details -> Settings, admins can choose which
-registered Telegram topic receives new agenda/bill messages and which topic
-receives paid confirmations.
-
-Do not expose the admin panel publicly until authentication is added. Use it
-only on LAN/VPN or behind a protected reverse proxy.
-
-## Bot Commands
-
-- `/agenda`
-- `/pagou`
-- `/whopaid`
-- `/registerpix`
-- `/delete`
-- `/cancel`
-- `/help`
-
-## Local Development
-
-Backend:
+Use Node.js 20 or newer and start PostgreSQL separately. Set `DATABASE_URL` for
+the backend and use separate terminals for each service.
 
 ```bash
+# Backend
 cd backend
 npm install
-npm run dev
+DATABASE_URL=postgres://telebot:password@localhost:5432/telebot npm run dev
 ```
 
-Bot:
-
 ```bash
+# Telegram bot
 cd tele_bot
 npm install
-BACKEND_URL=http://localhost:3000 npm run dev
+BOT_TOKEN=your_token BACKEND_URL=http://localhost:3000 npm run dev
 ```
 
-Admin panel:
-
 ```bash
+# Admin panel
 cd admin_panel
 npm install
 VITE_BACKEND_URL=http://localhost:3000 npm run dev
 ```
 
-## Notes
+## Production
 
-`tele_bot` communicates with `backend` only through
-`tele_bot/src/api/backendClient.js`. It does not import backend database or
-repository modules.
+The production Compose file uses images published to GitHub Container Registry:
 
-`admin_panel` communicates with `backend` only through
-`admin_panel/src/api/backendClient.js`. It does not import backend database or
-repository modules.
+```bash
+docker compose pull
+docker compose up -d
+docker compose ps
+```
+
+The admin image is built with Vite and served by nginx on container port `80`.
+To inspect a service, use `docker compose logs -f backend`, `tele_bot`, or
+`admin_panel`.
+
+## Contributing
+
+Contributions are welcome. Fork the repository, create a focused branch, and
+open a pull request describing the motivation, behavior change, and how you
+tested it. Keep credentials and local `.env` files out of commits.
+
+## License
+
+Distributed under the [MIT License](LICENSE).

--- a/backend/src/repositories/agenda.repository.js
+++ b/backend/src/repositories/agenda.repository.js
@@ -451,14 +451,8 @@ async function getAllAgendaPaymentBySender(senderId) {
              JOIN users creator ON creator.id = ap.created_by_user_id
              LEFT JOIN agenda_payment_members apm ON apm.agenda_payment_id = ap.id
              LEFT JOIN users member_user ON member_user.id = apm.user_id
-             WHERE (
-                creator.telegram_id = $1
-                OR (
-                    member_user.telegram_id = $1
-                    AND apm.is_responsible = TRUE
-                )
-             )
-               AND ap.is_fully_paid = FALSE
+             WHERE creator.telegram_id = $1
+              AND ap.is_fully_paid = FALSE
              ORDER BY ap.created_at ASC`,
       [senderId],
     );
@@ -472,6 +466,37 @@ async function getAllAgendaPaymentBySender(senderId) {
     return false;
   }
 }
+
+
+// async function getAllAgendaPaymentBySender(senderId) {
+//   try {
+//     const result = await query(
+//       `SELECT DISTINCT ap.id, ap.created_at
+//              FROM agenda_payments ap
+//              JOIN users creator ON creator.id = ap.created_by_user_id
+//              LEFT JOIN agenda_payment_members apm ON apm.agenda_payment_id = ap.id
+//              LEFT JOIN users member_user ON member_user.id = apm.user_id
+//              WHERE (
+//                 creator.telegram_id = $1
+//                 OR (
+//                     member_user.telegram_id = $1
+//                     AND apm.is_responsible = TRUE
+//                 )
+//              )
+//                AND ap.is_fully_paid = FALSE
+//              ORDER BY ap.created_at ASC`,
+//       [senderId],
+//     );
+
+//     const rows = await Promise.all(
+//       result.rows.map((row) => getAgendaPaymentById(row.id)),
+//     );
+//     return rows.filter(Boolean);
+//   } catch (error) {
+//     console.error("Error occurred during query:", error);
+//     return false;
+//   }
+// }
 
 /**
  * Retrieves all unpaid agenda payments.


### PR DESCRIPTION
This pull request updates the logic for retrieving agenda payments by sender in the `getAllAgendaPaymentBySender` function. The main change is to restrict the results to only those payments where the sender is the creator, rather than also including payments where the sender is a responsible member. The previous implementation is preserved as a commented-out block for reference.

**Agenda payment retrieval logic changes:**

* Updated the SQL query in `getAllAgendaPaymentBySender` to only include agenda payments where the sender is the creator (`creator.telegram_id = $1`), removing the condition that also included responsible members.
* Added the previous version of the function as a commented-out block for reference and potential rollback.